### PR TITLE
Updated docker-compose file

### DIFF
--- a/network/docker-compose.yml
+++ b/network/docker-compose.yml
@@ -64,12 +64,13 @@ services:
 
 volumes:
   authority1:
-    authority2:
-      mongodb-data:
-        mongodb-config:
-          networks:
-            dn:
-              driver: bridge
+  authority2:
+  mongodb-data:
+  mongodb-config:
+
+networks:
+  dn:
+    driver: bridge
     ipam:
       driver: default
       config:


### PR DESCRIPTION
There is an issue with the volumes section. 
The error message indicates : volumes.authority1 value 'authority2', 'ipam' do not match any of the regexes: '^x-' 
the 'authority2' and 'ipam' values for the 'volumes' section do not match any of the expected regular expressions.

To fix this error, I've added a new line before the 'authority2' volume to properly define it in the YAML format